### PR TITLE
enable output of initial displacement file and h0 parameter in gaussian 

### DIFF
--- a/src/JAGURS.f90
+++ b/src/JAGURS.f90
@@ -1825,6 +1825,16 @@ program JAGURS
 ! === Displacement =============================================================
                if((init_disp_fault == 1) .and. (ig == ngrid)) call displacement_finalize()
 ! ==============================================================================
+! === For MRI ==================================================================
+               else
+                  write(6,'(a,i0,a,f0.6,a,f0.6,a,f0.6,a,i0,a,i0,a,i0,a,a)') &
+                     'New rupture step: istep=', istep, ' dt=', dt, ' t=', t, ' tau=', tau, ' ig=', ig, &
+                     ' irupt=', irupt, ' nrupt=', nrupt, ' file=', trim(ruptgrd(irupt))
+                  TIMER_START('make_gaussian_rupture')
+                  call make_gaussian_rupture(dgrid(ig))
+                  TIMER_STOP('make_gaussian_rupture')
+               end if
+! ==============================================================================
 ! === Multiple rupture =========================================================
 #ifndef NCDIO
 #ifndef MPI
@@ -1851,17 +1861,6 @@ program JAGURS
 #else
                call write_initial_displacement(dgrid(ig), irupt)
 #endif
-! ==============================================================================
-! === For MRI ==================================================================
-               else
-                  write(6,'(a,i0,a,f0.6,a,f0.6,a,f0.6,a,i0,a,i0,a,i0,a,a)') &
-                     'New rupture step: istep=', istep, ' dt=', dt, ' t=', t, ' tau=', tau, ' ig=', ig, &
-                     ' irupt=', irupt, ' nrupt=', nrupt, ' file=', trim(ruptgrd(irupt))
-                  TIMER_START('make_gaussian_rupture')
-                  call make_gaussian_rupture(dgrid(ig))
-                  TIMER_STOP('make_gaussian_rupture')
-               end if
-! ==============================================================================
                jrupt = irupt
             end if
          end if

--- a/src/mod_init_disp_gaussian.f90
+++ b/src/mod_init_disp_gaussian.f90
@@ -8,12 +8,9 @@ implicit none
 real(kind=8), parameter, private :: R       = 6371.d0
 real(kind=8), parameter, private :: PI      = 3.14159265d0
 real(kind=8), parameter, private :: DEG2RAD = PI / 180.d0
-real(kind=8), parameter, private :: h0      = 1.0d0
-
-real(kind=8), private :: lon_o = 0.0d0, lat_o = 0.0d0, L = 0.0d0
-#else
-real(kind=8), private :: h0 = 1.0d0, lon_o = 0.0d0, lat_o = 0.0d0, L = 0.0d0
 #endif
+
+real(kind=8), private :: h0 = 1.0d0, lon_o = 0.0d0, lat_o = 0.0d0, L = 0.0d0
 
 private geth
 
@@ -21,11 +18,7 @@ contains
 
    subroutine specify_gaussian_params(file)
       character(len=256), intent(in) :: file
-#ifndef CARTESIAN
-      namelist /gaussian/ lon_o, lat_o, L
-#else
       namelist /gaussian/ h0, lon_o, lat_o, L
-#endif
 
       open(1,file=trim(file),action='read',status='old',form='formatted')
       read(1,gaussian)
@@ -36,6 +29,7 @@ contains
       write(6,'(a)') '============================================================'
       write(6,'(a,a)') '- Filename: ', trim(file)
 #ifndef CARTESIAN
+      write(6,'(a,f15.6)') '- Wave height[m] (h0):          ', h0
       write(6,'(a,f15.6)') '- Center lon.[Degrees] (lon_o): ', lon_o
       write(6,'(a,f15.6)') '- Center lat.[Degrees] (lat_o): ', lat_o
       write(6,'(a,f15.6)') '- Width[km] (L):                ', L


### PR DESCRIPTION
When using init_disp_gaussian=1, initial displacement file(s) was not created. I tried to fix it (JAGURS.f90).
When using init_disp_gaussian=1 with sperical polar coordinates, h0 parameter (wave height) can not be specified. I tried to fix it (mod_init_disp_gaussian.f90).