### PR TITLE
Supports proj.4 version 6.

### DIFF
--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H // for newer proj.4 version 6.0.0
 #include <proj_api.h>
 
 static  projPJ pj_tmerc, pj_latlong;


### PR DESCRIPTION
To use new version of proj.4 (e.g. current Homebrew), ACCEPT_USE_OF_DEPRECATED_PROJ_API_H should be #define'd in mapproject.c.

NOTE: proj_api.h will not be included as a public header file from PROJ 7.0.0.
see more detail in https://github.com/OSGeo/PROJ/issues/836
